### PR TITLE
Fix v.record output

### DIFF
--- a/src/parsers/parseObject.ts
+++ b/src/parsers/parseObject.ts
@@ -71,9 +71,8 @@ export function parseObject(schema: JsonSchemaObject, context: ParserContext): P
       // it's a part of v.object's signature.
     } else {
       // Only additionalProperties (as schema) is defined, no specific properties
-      // Use v.record(keyType, valueType) -> v.record(valueType) assuming string keys
       // For JSON schema, keys are always strings.
-      schemaStr = `v.record(${additionalResult.schema})`;
+      schemaStr = `v.record(v.string(), ${additionalResult.schema})`;
       allImports.add('record');
       allImports.delete('object'); // v.object might have been added by default
     }

--- a/test/jsonSchemaToValibot.test.ts
+++ b/test/jsonSchemaToValibot.test.ts
@@ -380,7 +380,7 @@ describe('jsonSchemaToValibot', () => {
       const result = jsonSchemaToValibot(schema);
 
       // Should use v.record when only additionalProperties is specified
-      expect(result).toContain('v.record(v.number())'); // Based on actual output
+      expect(result).toContain('v.record(v.string(), v.number())'); // Based on actual output
     });
 
     it('should handle complex additionalProperties with nested schema', () => {


### PR DESCRIPTION
Currently, when you have an object schema with only `additionalProperties`, you get the following:

Input:
```json
"features": {
   "type": "object",
    "additionalProperties": {
       "type": "boolean"
    }
}
```
Output:
```ts
features: v.record(v.boolean()),
```
Based on https://valibot.dev/api/record/ and the typescript types in `valibot@1.1.0` (current version), you _must_ provide the key type. 

This PR changes the output to:

```ts
features: v.record(v.string(), v.boolean()),
```

and updates the tests.