### PR TITLE
fix: map JSON Schema date-time format to v.isoTimestamp()

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ console.log(valibotCode)
 - `url`/`uri` → `v.url()`
 - `uuid` → `v.uuid()`
 - `date` → `v.isoDate()`
-- `date-time` → `v.isoDateTime()`
+- `date-time` → `v.isoTimestamp()`
 - `time` → `v.isoTime()`
 - `ipv4` → `v.ipv4()`
 - `ipv6` → `v.ipv6()`

--- a/src/parsers/parseString.ts
+++ b/src/parsers/parseString.ts
@@ -42,8 +42,8 @@ export function parseString(schema: JsonSchemaObject, _context: ParserContext): 
         imports.add('isoDate')
         break
       case 'date-time':
-        constraints.push('v.isoDateTime()')
-        imports.add('isoDateTime')
+        constraints.push('v.isoTimestamp()')
+        imports.add('isoTimestamp')
         break
       case 'time':
         constraints.push('v.isoTime()')

--- a/test/jsonSchemaToValibot.test.ts
+++ b/test/jsonSchemaToValibot.test.ts
@@ -22,6 +22,23 @@ describe('jsonSchemaToValibot', () => {
     expect(result).toContain('v.pipe(v.string(), v.minLength(5), v.maxLength(100), v.regex(/^[a-z]+$/))');
   });
 
+  it('should convert string format to corresponding valibot action', () => {
+    const cases: Array<[string, string]> = [
+      ['email', 'v.email()'],
+      ['uuid', 'v.uuid()'],
+      ['date', 'v.isoDate()'],
+      ['date-time', 'v.isoTimestamp()'],
+      ['time', 'v.isoTime()'],
+      ['ipv4', 'v.ipv4()'],
+      ['ipv6', 'v.ipv6()'],
+    ];
+
+    for (const [format, action] of cases) {
+      const result = jsonSchemaToValibot({ type: 'string' as const, format });
+      expect(result).toContain(`v.pipe(v.string(), ${action})`);
+    }
+  });
+
   it('should convert basic number schema', () => {
     const schema = { type: 'number' as const };
     const result = jsonSchemaToValibot(schema);


### PR DESCRIPTION
## 概要

JSON Schema の `date-time` フォーマットを `v.isoDateTime()` ではなく `v.isoTimestamp()` にマッピングするよう修正します。

## 背景

[RFC 3339 section 5.6](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#RFC3339) の `date-time` は秒と time-offset を含みます:

```
date-time = full-date "T" full-time
full-time = partial-time time-offset
```

一方 Valibot の使い分けは以下の通りで、`date-time` には `isoTimestamp()` が正しい対応です:

- [`v.isoDateTime()`](https://valibot.dev/api/isoDateTime/) — `YYYY-MM-DDTHH:MM`（秒・タイムゾーンなし）
- [`v.isoTimestamp()`](https://valibot.dev/api/isoTimestamp/) — 秒・タイムゾーンを含む完全なタイムスタンプ

## 変更内容

- `src/parsers/parseString.ts`: `date-time` → `v.isoTimestamp()`
- `README.md`: フォーマットマッピング表を更新

## 確認

- `pnpm typecheck` ✅
- `pnpm test:dev` ✅ (24 passed)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)